### PR TITLE
Add list of recommended families for setting the 'default' option in RMG

### DIFF
--- a/input/kinetics/families/recommended.py
+++ b/input/kinetics/families/recommended.py
@@ -1,0 +1,49 @@
+# This file contains a dictionary of kinetics families.  The families
+# set to `True` are recommended by RMG and turned on by default by setting
+# kineticsFamilies = 'default' in the RMG input file. Families set to `False` 
+# are not turned on by default because the family is severely lacking in data.
+# These families should only be turned on with caution.
+
+recommendedFamilies = {
+'1,2-Birad_to_alkene': True,
+'1,2_Insertion': True,
+'1,2_shiftS': True,
+'1,3_Insertion_CO2': True, 
+'1,3_Insertion_ROR': True,
+'1,3_Insertion_RSR': True,
+'1,4_Cyclic_birad_scission': True,
+'1,4_Linear_birad_scission': True,
+'1+2_Cycloaddition': True,
+'2+2_cycloaddition_CCO': True,
+'2+2_cycloaddition_Cd': True,
+'2+2_cycloaddition_CO': True,
+'Birad_recombination': True,
+'Cyclic_Ether_Formation': True,
+'Diels_alder_addition': True,
+'Disproportionation': True,
+'H_Abstraction': True,
+'HO2_Elimination_from_PeroxyRadical': True,
+'Intra_Diels_alder': True,
+'Intra_Disproportionation': True,
+'intra_H_migration': True,
+'intra_NO2_ONO_conversion': True,
+'intra_OH_migration': True,
+'Intra_R_Add_Endocyclic': True,
+'Intra_R_Add_Exocyclic': True,
+'intra_substitutionCS_cyclization': True,
+'intra_substitutionCS_isomerization': True,
+'intra_substitutionS_cyclization': True,
+'intra_substitutionS_isomerization': True,
+'ketoenol': True,
+'Korcek_step1': False,
+'Korcek_step2': False,
+'lone_electron_pair_bond': True,
+'Oa_R_Recombination': True,
+'R_Addition_COm': True,
+'R_Addition_CSm': True,
+'R_Addition_MultipleBond': True,
+'R_Recombination': True,
+'Substitution_O': True,
+'SubstitutionS': True,
+}
+


### PR DESCRIPTION
In conjunction with commit  https://github.com/connie/RMG-Py/commit/e5507408cd36bb7fcfeb09463d2f5d140f8fdfb7 in RMG-Py.

This commit adds a list of recommended families for setting a 'default,' much like RMG-Java.
It replaces the 'recommended' functionality that RMG-Py was potentially going to have.  
I think this format allows the user to more easily manipulate which families to turn on (even
though we allow more customizable functionality in the input.py file.)
