### PR TITLE
Corrected adjlists for USC-Mech-ii

### DIFF
--- a/input/thermo/libraries/USC-Mech-ii.py
+++ b/input/thermo/libraries/USC-Mech-ii.py
@@ -376,7 +376,7 @@ entry(
     molecule = 
 """
 multiplicity 1
-1 C u2 p0 c0  {2,S} {3,S}
+1 C u0 p1 c0  {2,S} {3,S}
 2 H u0 p0 c0  {1,S}
 3 H u0 p0 c0  {1,S}
 """,
@@ -733,7 +733,7 @@ entry(
     molecule = 
 """
 multiplicity 1
-1 C u2 p0 c0  {2,D}
+1 C u0 p1 c0  {2,D}
 2 C u0 p0 c0  {1,D} {3,S} {4,S}
 3 H u0 p0 c0  {2,S}
 4 H u0 p0 c0  {2,S}


### PR DESCRIPTION
The changeTripletToSinglet method in rmgpy/molecule/molecule was used for the singlet radical cases. The method  changes the multiplicity to 1, but the adjlist still reports the atom as having 2 unpaired electrons (instead of a lone pair and an empty shell). I can't remember if this is what we want or if this should have been corrected.

Should address #50.
