### PR TITLE
Forbid scission of opposite charges

### DIFF
--- a/input/kinetics/families/Birad_R_Recombination/groups.py
+++ b/input/kinetics/families/Birad_R_Recombination/groups.py
@@ -1018,3 +1018,16 @@ Group added to forbid this family from forming S-O chains
 """,
 )
 
+forbidden(
+    label = "charged",
+    group =
+"""
+1 *1 R!H ux c[-1,-2] {2,S}
+2 *2 R!H ux c[+1,+2] {1,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)

--- a/input/kinetics/families/Birad_recombination/groups.py
+++ b/input/kinetics/families/Birad_recombination/groups.py
@@ -1090,3 +1090,16 @@ u"""
 """,
 )
 
+forbidden(
+    label = "charged",
+    group =
+"""
+1 *1 R!H ux c[-1,-2] {2,S}
+2 *2 R!H ux c[+1,+2] {1,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)

--- a/input/kinetics/families/R_Recombination/groups.py
+++ b/input/kinetics/families/R_Recombination/groups.py
@@ -1843,3 +1843,16 @@ u"""
 """,
 )
 
+forbidden(
+    label = "charged",
+    group =
+"""
+1 *1 R!H ux c[-1,-2] {2,S}
+2 *2 R!H ux c[+1,+2] {1,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)


### PR DESCRIPTION
Scission of opposite charges forms two net charged species, and should be forbidden. Such pathway, if
allowed, should only occur through a different resonance structure of the species.

For example, one of the resonance structures of ![image](https://user-images.githubusercontent.com/16158262/39484931-45d2ecc4-4d45-11e8-9703-575a8ccc3d5c.png) is ![image](https://user-images.githubusercontent.com/16158262/39484960-57ae251c-4d45-11e8-8c2a-76fc7d4f54dc.png).
Once RMG tries to fit the latter into the `Birad_R_Recombination` template, it forms a real (not formal) charge separation: `[NH2..+]` and `[NH.-]` (dots represent radicals). In this case, the scission of the N-N bond should only be allowed through the first resonance structure.
This PR only forbids opposite charges from undergoing scission, and same-charge scission is still allowed, e.g.:
![image](https://user-images.githubusercontent.com/16158262/39485167-ffd0748e-4d45-11e8-997e-1cbd8ef11512.png) <-> ![image](https://user-images.githubusercontent.com/16158262/39485174-04d5dfd2-4d46-11e8-87ae-7c9a7dd174ad.png) + ![image](https://user-images.githubusercontent.com/16158262/39485178-05bdf254-4d46-11e8-9439-5021cec7ef43.png)


