### PR TITLE
Adding missing commas to coverage dependent parameters

### DIFF
--- a/input/kinetics/libraries/Surface/DOC/Nitrogen/reactions.py
+++ b/input/kinetics/libraries/Surface/DOC/Nitrogen/reactions.py
@@ -241,7 +241,7 @@ entry(
 #         Ea = (111.3, 'kJ/mol'),  
 #         Tmin = (200, 'K'),
 #         Tmax = (3000, 'K'),
-#         coverage_dependence = {'CO_X': {'a':0.0, 'm':0.0, 'E':(75, 'kJ/mol')}
+#         coverage_dependence = {'CO_X': {'a':0.0, 'm':0.0, 'E':(75, 'kJ/mol')},
 #                                'O_X': {'a':0.0, 'm':0.0, 'E':(-60, 'kJ/mol')}},
 #     ),
 #     shortDesc = u"""""",

--- a/input/kinetics/libraries/Surface/Methane/Vlachos_Pt111/reactions.py
+++ b/input/kinetics/libraries/Surface/Methane/Vlachos_Pt111/reactions.py
@@ -511,7 +511,7 @@ This is R19 in Table 1
 #         Ea = (63.0, 'kcal/mol'),  
 #         Tmin = (200, 'K'),
 #         Tmax = (3000, 'K'),
-#         coverage_dependence = {'O_X': {'a':0.0, 'm':0.0, 'E':(-33, 'kcal/mol')}
+#         coverage_dependence = {'O_X': {'a':0.0, 'm':0.0, 'E':(-33, 'kcal/mol')},
 #                                'H2O_X': {'a':0.0, 'm':0.0, 'E':(25, 'kcal/mol')}},
 #     ),
 #     shortDesc = u"""Surface_Adsorption_Single""",
@@ -561,8 +561,8 @@ This is R21 in Table 1
 #         Ea = (10, 'kcal/mol'),  
 #         Tmin = (200, 'K'),
 #         Tmax = (3000, 'K'),
-#         coverage_dependence = {'OH_X': {'a':0.0, 'm':0.0, 'E':(25, 'kcal/mol')}
-#                                'H2O_X': {'a':0.0, 'm':0.0, 'E':(-2.5, 'kcal/mol')}},        
+#         coverage_dependence = {'OH_X': {'a':0.0, 'm':0.0, 'E':(25, 'kcal/mol')},
+#                                'H2O_X': {'a':0.0, 'm':0.0, 'E':(-2.5, 'kcal/mol')}},
 #     ),
 #     shortDesc = u"""Surface_Adsorption_vdW""",
 #     longDesc = u"""

--- a/input/kinetics/libraries/Surface/Methane/Vlachos_Rh/reactions.py
+++ b/input/kinetics/libraries/Surface/Methane/Vlachos_Rh/reactions.py
@@ -42,7 +42,7 @@ This is R1 in Table 4
 #        Ea = (12.3, 'kcal/mol'),  
 #        Tmin = (200, 'K'),
 #        Tmax = (3000, 'K'),
-#        coverage_dependence = {'O_X': {'a':0.0, 'm':0.0, 'E':(-5, 'kcal/mol')}
+#        coverage_dependence = {'O_X': {'a':0.0, 'm':0.0, 'E':(-5, 'kcal/mol')},
 #                               'CO_X': {'a':0.0, 'm':0.0, 'E':(-7.4, 'kcal/mol')}},
 #    ),
 #    shortDesc = u"""H2 Surface_Adsorption_Dissociative""",
@@ -141,7 +141,7 @@ This is R13 in Table 4
 #         Ea = (7.5, 'kcal/mol'),  
 #         Tmin = (200, 'K'),
 #         Tmax = (3000, 'K'),
-#         coverage_dependence = {'H2O_X': {'a':0.0, 'm':0.0, 'E':(-4.5, 'kcal/mol')}
+#         coverage_dependence = {'H2O_X': {'a':0.0, 'm':0.0, 'E':(-4.5, 'kcal/mol')},
 #                                'OH_X': {'a':0.0, 'm':0.0, 'E':(25, 'kcal/mol')}},
 #     ),
 #     shortDesc = u"""Surface_Adsorption_vdW""",
@@ -187,7 +187,7 @@ This is R19 in Table 4
 #         Ea = (32.8, 'kcal/mol'),  
 #         Tmin = (200, 'K'),
 #         Tmax = (3000, 'K'),
-#         coverage_dependence = {'H_X': {'a':0.0, 'm':0.0, 'E':(-3.7, 'kcal/mol')}
+#         coverage_dependence = {'H_X': {'a':0.0, 'm':0.0, 'E':(-3.7, 'kcal/mol')},
 #                                'CO_X': {'a':0.0, 'm':0.0, 'E':(-15, 'kcal/mol')}},
 #     ),
 #     shortDesc = u"""Surface_Adsorption_Double""",


### PR DESCRIPTION
Some of the commented out reactions with coverage dependence with respect to multiple species were missing a comma. I just added in the commas