### PR TITLE
Update incorrect `Glarborg/C2` database entry

### DIFF
--- a/input/kinetics/libraries/Glarborg/C2/dictionary.txt
+++ b/input/kinetics/libraries/Glarborg/C2/dictionary.txt
@@ -389,3 +389,14 @@ multiplicity 2
 7 H u0 p0 c0 {2,S}
 8 H u0 p0 c0 {3,S}
 
+CH3CHOOH
+multiplicity 2
+1 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2 C u1 p0 c0 {1,S} {3,S} {8,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u0 p2 c0 {3,S} {9,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {1,S}
+8 H u0 p0 c0 {2,S}
+9 H u0 p0 c0 {4,S}

--- a/input/kinetics/libraries/Glarborg/C2/reactions.py
+++ b/input/kinetics/libraries/Glarborg/C2/reactions.py
@@ -3661,19 +3661,19 @@ entry(
         pressures = ([1, 10, 100], 'atm'),
         arrhenius = [
             Arrhenius(
-                A = (3.5e+12, 'cm^3/(mol*s)'),
+                A = (3.5e+12, 's^-1'),
                 n = -0.947,
                 Ea = (979, 'cal/mol'),
                 T0 = (1, 'K'),
             ),
             Arrhenius(
-                A = (3.5e+13, 'cm^3/(mol*s)'),
+                A = (3.5e+13, 's^-1'),
                 n = -0.947,
                 Ea = (980, 'cal/mol'),
                 T0 = (1, 'K'),
             ),
             Arrhenius(
-                A = (5.8e+14, 'cm^3/(mol*s)'),
+                A = (5.8e+14, 's^-1'),
                 n = -1.012,
                 Ea = (1068, 'cal/mol'),
                 T0 = (1, 'K'),

--- a/input/kinetics/libraries/Glarborg/C2/reactions.py
+++ b/input/kinetics/libraries/Glarborg/C2/reactions.py
@@ -3655,7 +3655,7 @@ entry(
 
 entry(
     index = 403,
-    label = "CH3CHO + OH <=> CH3CHO + OH",
+    label = "CH3CHOOH <=> CH3CHO + OH",
     degeneracy = 1,
     kinetics = PDepArrhenius(
         pressures = ([1, 10, 100], 'atm'),


### PR DESCRIPTION
Glarborg's thesis has the entry as `CH3CHOOH -> CH3CHO + OH`. The previous entry was malformed as a symmetric reaction.

See https://backend.orbit.dtu.dk/ws/portalfiles/portal/4727804/PhDThesis_CLR_Printing.pdf (see Ch. 5.3 Table 5.4 pg. 133, entry 182). Many thanks to Timo Pekkanen for finding the original source.

The original, malformed entry is especially problematic because it is a symmetric reaction which is parsed by `RMG` to return `None`. This can lead to crashes if this library is used.