### PR TITLE
Add new Formic_Acid library

### DIFF
--- a/input/kinetics/libraries/FormicAcid/dictionary.txt
+++ b/input/kinetics/libraries/FormicAcid/dictionary.txt
@@ -1,0 +1,190 @@
+HOCHO
+1 O u0 p2 c0 {2,S} {4,S}
+2 C u0 p0 c0 {1,S} {3,D} {5,S}
+3 O u0 p2 c0 {2,D}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+
+CO
+1 C u0 p1 c-1 {2,T}
+2 O u0 p1 c+1 {1,T}
+
+H2O
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+CO2
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 O u0 p2 c0 {2,D}
+
+H2
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+OH
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+HOCO
+multiplicity 2
+1 O u0 p2 c0 {2,S} {4,S}
+2 C u1 p0 c0 {1,S} {3,D}
+3 O u0 p2 c0 {2,D}
+4 H u0 p0 c0 {1,S}
+
+OCHO
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 C u0 p0 c0 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 H u0 p0 c0 {2,S}
+
+HO2
+multiplicity 2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+H2O2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+
+O2
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+
+HOC(O)OO
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 C u0 p0 c0 {2,S} {4,D} {5,S}
+4 O u0 p2 c0 {3,D}
+5 O u0 p2 c0 {3,S} {6,S}
+6 H u0 p0 c0 {5,S}
+
+HOCOO
+multiplicity 2
+1 O u0 p2 c0 {2,S} {5,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,D}
+3 O u1 p2 c0 {2,S}
+4 O u0 p2 c0 {2,D}
+5 H u0 p0 c0 {1,S}
+
+CO3
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u0 p2 c0 {2,S} {3,S}
+
+HOC(O)OOH
+1 O u0 p2 c0 {2,S} {6,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 C u0 p0 c0 {2,S} {4,D} {5,S}
+4 O u0 p2 c0 {3,D}
+5 O u0 p2 c0 {3,S} {7,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {5,S}
+
+HCO(OH)2
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u1 p2 c0 {1,S}
+3 O u0 p2 c0 {1,S} {6,S}
+4 O u0 p2 c0 {1,S} {7,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+
+CO(OH)2
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 O u0 p2 c0 {1,S} {5,S}
+4 O u0 p2 c0 {1,S} {6,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+
+DHC
+multiplicity 1
+1 O u0 p2 c0 {2,S} {4,S}
+2 C u0 p1 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {5,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {3,S}
+
+HCO
+multiplicity 2
+1 C u1 p0 c0 {2,D} {3,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+
+O[CH]O
+multiplicity 2
+1 O u0 p2 c0 {2,S} {4,S}
+2 C u1 p0 c0 {1,S} {3,S} {5,S}
+3 O u0 p2 c0 {2,S} {6,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+
+[O]CO
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 O u0 p2 c0 {2,S} {6,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+
+CH2O
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+O[C](O)O
+multiplicity 2
+1 O u0 p2 c0 {2,S} {5,S}
+2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3 O u0 p2 c0 {2,S} {6,S}
+4 O u0 p2 c0 {2,S} {7,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+
+[O]C(O)O
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 O u0 p2 c0 {2,S} {6,S}
+4 O u0 p2 c0 {2,S} {7,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+
+O[CH]OO
+multiplicity 2
+1 O u0 p2 c0 {2,S} {5,S}
+2 C u1 p0 c0 {1,S} {3,S} {6,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u0 p2 c0 {3,S} {7,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {4,S}
+
+O=C(O)O
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 O u0 p2 c0 {2,S} {5,S}
+4 O u0 p2 c0 {2,S} {6,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+
+H
+multiplicity 2
+1 H u1 p0 c0

--- a/input/kinetics/libraries/FormicAcid/reactions.py
+++ b/input/kinetics/libraries/FormicAcid/reactions.py
@@ -1,0 +1,1230 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "FormicAcid"
+shortDesc = u"FormicAcid"
+longDesc = u"""
+Reference legend:
+[Nguyen2012] Thanh Lam Nguyen, Bert C. Xue, Ralph E. Weston, Jr., John R. Barker, and John F. Stanton, "Reaction of HO with CO: Tunneling Is Indeed Important", J. Phys. Chem. Lett. 2012, 3, 1549-1553, dx.doi.org/10.1021/jz300443a
+[Yin2021] Geyuan Yin, Jiawei Xu, Erjiang Hu, Qunfei Gao, Haochen Zhan, Zuohua Huang, "Experimental and kinetic study on the low temperature oxidation and pyrolysis of formic acid in a jet-stirred reactor", Combustion and Flame 223 (2021) 77-87, https://doi.org/10.1016/j.combustflame.2020.10.005
+
+"""
+entry(
+    index=1,
+    label="OH + CO <=> OCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [5.388, 1.727, -0.1527, -0.05968],
+            [2.432, 0.1733, 0.07411, 0.01318],
+            [0.3921, -0.04661, -0.01441, 0.001791],
+            [0.01330, 0.001915, -0.0002359, -0.0008834],
+            [-0.02258, 0.009316, 0.003324, 0.0004467],
+            [-0.01378, -0.003906, -0.0004662, 0.0005825],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc=u"""[Nguyen2012]""",
+    longDesc=
+    u"""
+    Calculated based on the HEAT (High-accuracy Extrapolated Ab initio Thermochemistry) protocol, specifically the HEAT-345Q variant, as detailed in [Nguyen2012].
+    T range: 50-2500 K; calculations focus on the zero- and high-pressure limits.This calculation explicitly accounts for quantum mechanical tunneling effects using semiclassical transition state theory (SCTST), which incorporates fully coupled vibrations and multidimensional tunneling.   
+    """,
+)
+
+entry(
+    index=2,
+    label="H + CO2 <=> OCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [4.637, 1.908, -0.02671, -0.01287],
+            [4.796, 0.08414, 0.01357, 0.006043],
+            [-0.08730, -0.002177, 0.004252, 0.001830],
+            [-0.03090, -0.002453, 0.001155, 0.0005792],
+            [-0.04060, 0.002115, 0.001512, 0.0007442],
+            [-0.01958, -0.0009371, -0.00007545, -0.00009391],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc=u"""[Nguyen2012]""",
+    longDesc=
+    u"""
+    Calculated based on the HEAT (High-accuracy Extrapolated Ab initio Thermochemistry) protocol, specifically the HEAT-345Q variant, as detailed in [Nguyen2012].
+    T range: 50-2500 K; calculations focus on the zero- and high-pressure limits.This calculation explicitly accounts for quantum mechanical tunneling effects using semiclassical transition state theory (SCTST), which incorporates fully coupled vibrations and multidimensional tunneling.   
+    """,
+)
+
+entry(
+    index=3,
+    label="H + CO2 <=> OH + CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [3.059, -0.4682, -0.2248, -0.06454],
+            [8.829, 0.3524, 0.1352, 0.01461],
+            [0.1047, -0.001557, 0.005639, 0.004925],
+            [0.01399, -0.03095, -0.008608, 0.0005584],
+            [0.01784, 0.006885, 0.0002928, -0.0006501],
+            [0.0003425, -0.003347, -0.0001403, 0.0003884],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc=u"""[Nguyen2012]""",
+    longDesc=
+    u"""
+    Calculated based on the HEAT (High-accuracy Extrapolated Ab initio Thermochemistry) protocol, specifically the HEAT-345Q variant, as detailed in [Nguyen2012].
+    T range: 50-2500 K; calculations focus on the zero- and high-pressure limits.This calculation explicitly accounts for quantum mechanical tunneling effects using semiclassical transition state theory (SCTST), which incorporates fully coupled vibrations and multidimensional tunneling.   
+    """,
+)
+
+entry(
+    index=4,
+    label="OCHO <=> HOCO",
+    kinetics = Chebyshev(
+        coeffs=[
+            [0.420904,2.57537,0.122185,-0.0347698],
+            [3.58675,1.71885,-0.232939,-0.0228968],
+            [0.64999,-0.293929,-0.0209092,0.0510844],
+            [-0.0172581,-0.175944,0.0797736,-0.0274859],
+            [-0.106711,0.0267121,-0.0103067,-0.00999137],
+            [-0.0910028,0.0427277,-0.0124742,0.0123547]], 
+        kunits='1/s', 
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+        ),
+    shortDesc=u"""[Nguyen2012]""",
+    longDesc=
+    u"""
+    Calculated based on the HEAT (High-accuracy Extrapolated Ab initio Thermochemistry) protocol, specifically the HEAT-345Q variant, as detailed in [Nguyen2012].
+    T range: 50-2500 K; calculations focus on the zero- and high-pressure limits.This calculation explicitly accounts for quantum mechanical tunneling effects using semiclassical transition state theory (SCTST), which incorporates fully coupled vibrations and multidimensional tunneling.   
+    """,
+)
+
+entry(
+    index=5,
+    label="OH + CO <=> HOCO",
+    kinetics = Chebyshev(
+        coeffs=[
+            [10.1179,1.31016,-0.294335,-0.0623058],
+            [-0.209461,0.426599,0.143929,0.00526051],
+            [-0.141944,0.0518631,0.0213173,0.00335184],
+            [0.00848119,-0.0199697,-5.42516e-05,0.00254578],
+            [-0.0427365,0.0131247,0.00219256,-0.000506071],
+            [-0.0140018,3.15098e-07,0.00127432,0.000548326]], 
+        kunits='cm^3/(mol*s)', 
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+        ),
+    shortDesc=u"""[Nguyen2012]""",
+    longDesc=
+    u"""
+    Calculated based on the HEAT (High-accuracy Extrapolated Ab initio Thermochemistry) protocol, specifically the HEAT-345Q variant, as detailed in [Nguyen2012].
+    T range: 50-2500 K; calculations focus on the zero- and high-pressure limits.This calculation explicitly accounts for quantum mechanical tunneling effects using semiclassical transition state theory (SCTST), which incorporates fully coupled vibrations and multidimensional tunneling.   
+    """,
+)
+
+entry(
+    index=6,
+    label="H + CO2 <=> HOCO",
+    kinetics = Chebyshev(
+        coeffs=[
+            [3.4677,0.606341,-0.0530739,0.000119584],
+            [5.85303,0.82429,-0.0432387,-0.00493425],
+            [0.182803,0.227552,0.02043,-0.00698013],
+            [-0.201013,0.0109382,0.0146266,-0.0029227],
+            [-0.0326655,0.0159478,-0.00017484,-0.000757879],
+            [-0.0142236,0.0138451,-0.00155517,-0.000505843]], 
+        kunits='cm^3/(mol*s)', 
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+        ),
+    shortDesc=u"""[Nguyen2012]""",
+    longDesc=
+    u"""
+    Calculated based on the HEAT (High-accuracy Extrapolated Ab initio Thermochemistry) protocol, specifically the HEAT-345Q variant, as detailed in [Nguyen2012].
+    T range: 50-2500 K; calculations focus on the zero- and high-pressure limits.This calculation explicitly accounts for quantum mechanical tunneling effects using semiclassical transition state theory (SCTST), which incorporates fully coupled vibrations and multidimensional tunneling.   
+    """,
+)
+
+entry(
+    index=7,
+    label="DHC <=> HOCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-0.05729, 1.105, -0.04740, -0.02741],
+            [7.095, 1.504, -0.02855, -0.03402],
+            [-0.1435, 0.3940, 0.03444, 0.0009022],
+            [-0.4761, -0.01620, 0.01108, 0.009874],
+            [-0.08182, 0.001355, -0.009023, 0.002340],
+            [-0.02575, 0.003575, -0.003538, 0.0004563],
+        ],
+        kunits = 's^-1',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=8,
+    label="HOCHO <=> H2O + CO",
+    kinetics=Lindemann(
+        arrheniusHigh=Arrhenius(A=(8.02386e-07,'1/s'), n=4.85458, Ea=(29.16,'kcal/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(3000,'K')),
+        arrheniusLow=Arrhenius(A=(0.019326,'cm^3/(mol*s)'), n=6.3478, Ea=(56.063,'kcal/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(3000,'K'))
+        ),
+    elementary_high_p = True,
+)
+
+entry(
+    index=9,
+    label="H + HOCO <=> HOCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [8.891, 1.959, -0.02788, -0.01461],
+            [-2.876, 0.04622, 0.03077, 0.01582],
+            [-1.084, -0.005835, -0.003577, -0.00155],
+            [-0.4478, -0.002435, -0.001716, -0.0009703],
+            [-0.1701, -0.0001163, -0.0001118, -0.00009017],
+            [-0.04983, -0.0002779, -0.0001883, -0.00009993],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=10,
+    label="H + OCHO <=> HOCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [15.92, 2.0, -0.00005003, -0.00002776],
+            [-1.927, 0.00008454, 0.00005882, 0.00003263],
+            [-0.5948, -0.00001253, -0.000008713, -0.00000483],
+            [-0.1942, -0.000006438, -0.000004479, -0.000002484],
+            [-0.05612, 0.000005194, 0.000003611, 0.000002002],
+            [0.006008, -0.000002801, -0.000001949, -0.000001081],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=11,
+    label="HOCHO <=> H2 + CO2",
+    kinetics=Lindemann(
+        arrheniusHigh=Arrhenius(A=(1.8036e+16,'1/s'), n=-1, Ea=(57.12,'kcal/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(3000,'K')), # "Fitted at 1e6 bar"
+        arrheniusLow=Arrhenius(A=(2.86299e-10,'cm^3/(mol*s)'), n=7.32655, Ea=(30.9089,'kcal/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(3000,'K'))  # "Fitted at 1e-4 bar"
+        ),
+    elementary_high_p = True,
+)
+
+entry(
+    index=12,
+    label="OH + HCO <=> HOCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [11.64, 1.981, -0.01284, -0.006974],
+            [-2.313, 0.01846, 0.01261, 0.006787],
+            [-0.8677, -0.00132, -0.0008493, -0.0004084],
+            [-0.3094, -0.0008318, -0.0005785, -0.0003207],
+            [-0.1058, -0.0002435, -0.000173, -0.00009921],
+            [-0.03072, -0.0003188, -0.0002205, -0.0001212],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=13,
+    label="H2O + CO <=> DHC",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-16.32, 0.711, -0.05305, -0.00884],
+            [20.51, 0.9595, -0.04531, -0.01125],
+            [0.3948, 0.2292, 0.02868, 0.0001393],
+            [-0.1414, -0.02865, 0.02227, 0.004465],
+            [0.04388, -0.004205, 0.001356, 0.001804],
+            [-0.006544, 0.0009985, 0.0007011, 0.0003122],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=14,
+    label="H + HOCO <=> DHC",
+    kinetics = Chebyshev(
+        coeffs = [
+            [7.122, 1.952, -0.03219, -0.01699],
+            [-2.268, 0.04953, 0.03308, 0.0171],
+            [-0.7048, -0.009307, -0.005978, -0.002868],
+            [-0.3166, -0.003328, -0.00234, -0.00132],
+            [-0.168, -0.0004618, -0.0003502, -0.0002207],
+            [-0.08127, -0.0005667, -0.0003872, -0.0002085],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=15,
+    label="H + OCHO <=> DHC",
+    kinetics = Chebyshev(
+        coeffs = [
+            [14.32, 1.997, -0.002239, -0.00124],
+            [-1.34, 0.001442, 0.001001, 0.0005534],
+            [-0.1912, -0.001303, -0.0009037, -0.000499],
+            [-0.04142, -0.0003955, -0.0002748, -0.0001522],
+            [-0.04219, -0.0001095, -0.00007576, -0.00004162],
+            [-0.02, -0.00006951, -0.00004803, -0.00002634],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=16,
+    label="H2 + CO2 <=> DHC",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-19.83, 0.652, -0.0194, -0.003509],
+            [23.96, 1.099, -0.06154, -0.009495],
+            [0.326, 0.3189, 0.0213, -0.01288],
+            [-0.1497, -0.1112, 0.02932, 0.01057],
+            [0.05797, -0.02494, -0.004921, 0.006388],
+            [-0.00528, 0.001966, 0.004679, -0.002187],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=17,
+    label="OH + HCO <=> DHC",
+    kinetics = Chebyshev(
+        coeffs = [
+            [9.986, 1.977, -0.01555, -0.008473],
+            [-1.775, 0.01917, 0.01311, 0.007062],
+            [-0.4947, -0.003316, -0.002234, -0.001173],
+            [-0.1741, -0.001685, -0.001171, -0.0006478],
+            [-0.1019, -0.0006591, -0.0004607, -0.0002576],
+            [-0.06239, -0.0005773, -0.0003993, -0.0002195],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=18,
+    label="H + HOCO <=> H2O + CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [11.62, -0.0402, -0.02707, -0.0142],
+            [-2.084, 0.04523, 0.03015, 0.01553],
+            [-0.9314, -0.006453, -0.00401, -0.001792],
+            [-0.4501, -0.002296, -0.001628, -0.0009297],
+            [-0.2005, 0.0000179, -0.00001805, -0.00003786],
+            [-0.08484, -0.0002736, -0.0001841, -0.00009657],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=19,
+    label="H + OCHO <=> H2O + CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [19.02, -0.000187, -0.0001299, -0.00007185],
+            [-1.171, 0.0001307, 0.0000907, 0.00005013],
+            [-0.3786, -0.00006145, -0.00004256, -0.00002344],
+            [-0.1414, -0.00002084, -0.00001449, -0.000008026],
+            [-0.05644, 0.000001293, 0.0000009187, 0.0000005269],
+            [-0.01467, -0.000004377, -0.00000303, -0.000001667],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=20,
+    label="H2 + CO2 <=> H2O + CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-16.83, -1.009, -0.1218, 0.004345],
+            [24.68, 0.9991, 0.02991, -0.0251],
+            [0.2019, 0.1252, 0.09434, 0.004163],
+            [-0.03739, -0.07801, 0.01424, 0.01375],
+            [-0.02653, -0.0501, -0.01687, 0.002151],
+            [-0.02236, -0.01356, -0.01116, -0.002793],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=21,
+    label="OH + HCO <=> H2O + CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [14.62, -0.01874, -0.01287, -0.006992],
+            [-1.68, 0.01837, 0.01255, 0.006759],
+            [-0.7284, -0.001368, -0.0008837, -0.0004281],
+            [-0.3016, -0.0008572, -0.000596, -0.0003302],
+            [-0.1324, -0.0002546, -0.0001805, -0.0001033],
+            [-0.06638, -0.0003249, -0.0002247, -0.0001234],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=22,
+    label="H + OCHO <=> H + HOCO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [15.74, -0.00005110, -0.00003556, -0.00001973],
+            [-2.304, 0.00006780, 0.00004717, 0.00002617],
+            [-0.5025, -0.00001445, -0.00001005, -0.000005575],
+            [-0.1259, -0.000004860, -0.000003381, -0.000001876],
+            [-0.03337, 0.000004344, 0.000003020, 0.000001674],
+            [-0.004068, -0.000001114, -0.0000007750, -0.0000004298],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=23,
+    label="H2 + CO2 <=> H + HOCO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-29.53, -0.04019, -0.02707, -0.0142],
+            [32.11, 0.04516, 0.0301, 0.01551],
+            [-0.8388, -0.006567, -0.004089, -0.001836],
+            [-0.4164, -0.002302, -0.001633, -0.000933],
+            [-0.1897, 0.00001976, -0.00001659, -0.0000369],
+            [-0.08169, -0.0002816, -0.0001895, -0.00009936],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=24,
+    label="OH + HCO <=> H + HOCO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [10.84, -0.01816, -0.01248, -0.006779],
+            [-3.293, 0.01813, 0.01239, 0.006677],
+            [-1.132, -0.001064, -0.0006753, -0.0003159],
+            [-0.4248, -0.0006782, -0.0004713, -0.0002608],
+            [-0.1703, -0.0001173, -0.00008513, -0.00005043],
+            [-0.07713, -0.0002142, -0.0001478, -0.0000809],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=25,
+    label="H2 + CO2 <=> H + OCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-27.38, -0.0002866, -0.000199, -0.0001100],
+            [36.27, 0.0001673, 0.0001160, 0.00006404],
+            [-0.4730, -0.0001037, -0.00007183, -0.00003954],
+            [-0.1704, -0.00003458, -0.00002404, -0.00001332],
+            [-0.06662, -0.000003033, -0.000002076, -0.000001121],
+            [-0.01812, -0.000006496, -0.000004493, -0.000002468],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=26,
+    label="OH + HCO <=> H + OCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [16.67, -0.00001718, -0.00001195, -0.000006631],
+            [0.5377, 0.00002599, 0.00001808, 0.00001003],
+            [0.08324, -0.00001008, -0.000007013, -0.000003891],
+            [0.04499, 0.000000264, 0.0000001835, 0.0000001016],
+            [0.01633, 0.000001546, 0.000001075, 0.0000005963],
+            [0.006718, -0.0000003296, -0.0000002292, -0.0000001270],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=27,
+    label="OH + HCO <=> H2 + CO2",
+    kinetics = Chebyshev(
+        coeffs = [
+            [13.59, -0.01884, -0.01294, -0.007032],
+            [-1.678, 0.01838, 0.01256, 0.006763],
+            [-0.7243, -0.001424, -0.0009219, -0.0004491],
+            [-0.3006, -0.0008813, -0.0006127, -0.0003394],
+            [-0.1330, -0.0002660, -0.0001884, -0.0001076],
+            [-0.06674, -0.0003317, -0.0002294, -0.0001260],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin=(300,'K'), 
+        Tmax=(3000,'K'), 
+        Pmin=(0.01,'bar'), 
+        Pmax=(100,'bar')
+    ),
+    shortDesc=u"""FormicAcid""",
+    longDesc=
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH2O2 PES calculated at
+    the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.    
+    """,
+)
+
+entry(
+    index=28,
+    label = 'HOCHO + OH <=> HOCO + H2O', 
+    kinetics = Arrhenius(
+        A = (30703.2, 'cm^3/(mol*s)'),
+        n = 2.52013,
+        Ea = (29.3851, 'kJ/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc=u"""CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP""",
+    longDesc=
+    u"""
+    Calculated at the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.
+    """,
+)
+
+entry(
+    index=29,
+    label = 'HOCHO + OH <=> OCHO + H2O', 
+    kinetics = Arrhenius(
+        A = (0.0765648, 'cm^3/(mol*s)'),
+        n = 4.05778,
+        Ea = (41.3556, 'kJ/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    shortDesc=u"""CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP""",
+    longDesc=
+    u"""
+    Calculated at the CCSD(T)-F12/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory.
+    H_abs reaction, ARC couldn't caluclate the reversed reaction rate.   
+    """,
+)
+
+entry(
+    index = 30,
+    label = "O[CH]O <=> [O]CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-3.263e+00,  2.508e+00, -3.981e-02, -2.895e-02],
+            [ 6.742e+00,  1.623e+00, -1.532e-02, -2.171e-02],
+            [ 1.358e-01, -4.110e-02, -3.889e-02,  2.964e-02],
+            [-9.837e-02, -1.858e-01,  3.196e-02,  1.486e-02],
+            [-3.340e-02, -2.708e-02,  2.709e-02, -1.041e-02],
+            [-2.395e-02,  3.246e-02, -1.629e-03, -6.735e-03],
+        ],
+        kunits = '1/s',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the doublet CH3O2 PES calculated at
+    the ccsd(t)_l/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory. 
+    """,
+)
+
+entry(
+    index = 31,
+    label = "H + HOCHO <=> [O]CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [ 6.678e+00,  1.511e+00, -8.362e-02, -1.392e-02],
+            [ 2.017e+00,  5.578e-01,  6.967e-02,  4.345e-03],
+            [-2.708e-01, -2.456e-02,  2.279e-02,  1.029e-02],
+            [-1.133e-01, -2.994e-02, -9.507e-04,  1.516e-03],
+            [ 2.983e-03, -1.883e-02, -6.767e-03, -1.709e-03],
+            [ 1.890e-02, -3.352e-03, -3.930e-03, -1.316e-03],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc =
+    u"""
+    From the pressure-dependent kinetic network of the doublet CH3O2 PES calculated at
+    the ccsd(t)_l/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory. 
+    """,
+)
+
+entry(
+    index = 32,
+    label = "OH + CH2O <=> [O]CO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-3.794e+00,  1.999e+00, -9.837e-04, -5.451e-04],
+            [ 9.509e+00,  5.474e-04,  3.802e-04,  2.104e-04],
+            [ 3.300e-03,  5.541e-04,  3.855e-04,  2.138e-04],
+            [-1.867e-02,  1.715e-04,  1.193e-04,  6.612e-05],
+            [ 3.244e-02, -1.409e-04, -9.790e-05, -5.418e-05],
+            [ 1.812e-02, -8.475e-05, -5.888e-05, -3.259e-05],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc =
+    u"""
+    From the pressure-dependent kinetic network of the doublet CH3O2 PES calculated at
+    the ccsd(t)_l/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory. 
+    """,
+)
+
+entry(
+    index = 33,
+    label = "H + HOCHO <=> O[CH]O",
+    kinetics = Chebyshev(
+        coeffs = [
+            [ 6.919e+00,  7.616e-01, -8.212e-02, -6.470e-03],
+            [ 2.947e+00,  9.417e-01, -3.805e-02, -1.510e-02],
+            [-8.917e-02,  2.060e-01,  5.011e-02,  2.063e-04],
+            [-1.341e-01, -1.281e-02,  2.149e-02,  6.413e-03],
+            [-1.739e-02, -6.379e-03,  1.350e-04,  1.080e-03],
+            [-9.173e-03,  2.179e-03,  9.040e-04, -7.113e-04],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc =
+    u"""
+    From the pressure-dependent kinetic network of the doublet CH3O2 PES calculated at
+    the ccsd(t)_l/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory. 
+    """,
+)
+
+entry(
+    index = 34,
+    label = "OH + CH2O <=> O[CH]O",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-4.225e+00,  1.988e+00, -8.480e-03, -4.657e-03],
+            [ 9.526e+00,  1.004e-02,  6.912e-03,  3.770e-03],
+            [ 3.734e-01, -2.259e-03, -1.538e-03, -8.233e-04],
+            [ 1.696e-01, -8.566e-05, -6.527e-05, -4.137e-05],
+            [ 4.325e-02,  1.286e-04,  8.887e-05,  4.877e-05],
+            [ 2.101e-03,  7.872e-05,  5.487e-05,  3.053e-05],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc =
+    u"""
+    From the pressure-dependent kinetic network of the doublet CH3O2 PES calculated at
+    the ccsd(t)_l/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory. 
+    """,
+)
+
+entry(
+    index = 35,
+    label = "OH + CH2O <=> H + HOCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [ 3.160e-01, -1.797e-03, -1.246e-03, -6.877e-04],
+            [ 9.798e+00,  8.284e-04,  5.711e-04,  3.121e-04],
+            [ 2.623e-01,  4.407e-04,  3.087e-04,  1.731e-04],
+            [ 1.005e-01,  1.382e-04,  9.580e-05,  5.281e-05],
+            [ 3.925e-02, -1.385e-04, -9.626e-05, -5.334e-05],
+            [ 1.606e-02, -7.905e-05, -5.492e-05, -3.039e-05],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc =
+    u"""
+    From the pressure-dependent kinetic network of the doublet CH3O2 PES calculated at
+    the ccsd(t)_l/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory. 
+    """,
+)
+
+entry(
+    index = 36,
+    label = "O[C](O)O <=> [O]C(O)O",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-2.353e+00,  3.617e+00, -1.585e-01, -2.995e-02],
+            [ 6.817e+00,  3.862e-01,  1.406e-01,  1.211e-02],
+            [-1.817e-01,  4.256e-02,  3.099e-02,  1.528e-02],
+            [-1.028e-01, -4.070e-02, -8.814e-03,  3.993e-03],
+            [-4.527e-02, -2.106e-02, -1.029e-02, -2.305e-03],
+            [-3.803e-02,  6.337e-03, -6.571e-04, -2.129e-03],
+        ],
+        kunits = '1/s',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH3O3 PES calculated at
+    the ccsd(t)_l/aug-cc-pVTZ-F12//B2PLYP-D3/def2-TZVP level of theory. 
+    """,
+)
+
+entry(
+    index = 37,
+    label = "OH + HOCHO <=> [O]C(O)O",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-1.187e+01,  1.985e+00, -1.028e-02, -5.627e-03],
+            [ 1.632e+01,  6.465e-03,  4.453e-03,  2.429e-03],
+            [-5.463e-02,  7.211e-03,  4.951e-03,  2.687e-03],
+            [ 2.838e-02, -7.815e-04, -5.237e-04, -2.723e-04],
+            [ 3.661e-02, -1.732e-03, -1.179e-03, -6.302e-04],
+            [-6.361e-03,  6.712e-04,  4.549e-04,  2.414e-04],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH3O3 PES calculated at
+    the ccsd(t)_l/aug-cc-pvtz-f12//b2plyp-d3/def2-tzvp level of theory. 
+    """,
+)
+
+entry(
+    index = 38,
+    label = "H + O=C(O)O <=> [O]C(O)O",
+    kinetics = Chebyshev(
+        coeffs = [
+            [ 3.201e+00,  1.648e+00, -1.495e-01, -3.074e-02],
+            [ 5.271e+00,  3.678e-01,  1.387e-01,  1.526e-02],
+            [-2.407e-01,  2.690e-02,  2.574e-02,  1.521e-02],
+            [-3.930e-02, -4.126e-02, -1.137e-02,  2.302e-03],
+            [ 1.976e-02, -1.811e-02, -1.020e-02, -3.122e-03],
+            [-1.857e-03,  7.537e-03,  3.198e-04, -1.897e-03],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH3O3 PES calculated at
+    the ccsd(t)_l/aug-cc-pvtz-f12//b2plyp-d3/def2-tzvp level of theory. 
+    """,
+)
+
+entry(
+    index = 39,
+    label = "OH + HOCHO <=> O[C](O)O",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-1.348e+01,  1.985e+00, -1.051e-02, -5.758e-03],
+            [ 1.689e+01,  6.231e-03,  4.290e-03,  2.338e-03],
+            [ 3.916e-01,  7.044e-03,  4.835e-03,  2.622e-03],
+            [ 6.973e-02, -8.127e-04, -5.453e-04, -2.842e-04],
+            [-7.473e-03, -1.706e-03, -1.161e-03, -6.205e-04],
+            [-9.800e-03,  7.061e-04,  4.792e-04,  2.549e-04],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH3O3 PES calculated at
+    the ccsd(t)_l/aug-cc-pvtz-f12//b2plyp-d3/def2-tzvp level of theory. 
+    """,
+)
+
+entry(
+    index = 40,
+    label = "H + O=C(O)O <=> O[C](O)O",
+    kinetics = Chebyshev(
+        coeffs = [
+            [ 9.773e+00,  1.886e+00, -5.947e-02, -1.793e-02],
+            [-4.793e-01,  1.359e-01,  6.881e-02,  1.886e-02],
+            [ 3.453e-02, -1.778e-02, -7.556e-03, -6.586e-04],
+            [ 3.256e-02, -4.239e-03, -2.468e-03, -8.271e-04],
+            [-9.001e-05, -1.531e-03, -6.284e-04, -7.294e-05],
+            [-6.643e-03, -4.835e-04, -1.945e-04, -4.952e-05],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH3O3 PES calculated at
+    the ccsd(t)_l/aug-cc-pvtz-f12//b2plyp-d3/def2-tzvp level of theory. 
+    """,
+)
+
+entry(
+    index = 41,
+    label = "OH + HOCHO <=> O[CH]OO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-1.419e+01,  1.492e+00, -1.553e-01, -3.404e-02],
+            [ 1.878e+01,  5.057e-01,  1.081e-01,  8.756e-03],
+            [-9.685e-02,  4.333e-02,  5.102e-02,  1.522e-02],
+            [ 3.389e-02, -4.685e-02, -5.648e-03,  6.717e-03],
+            [ 3.642e-02, -2.055e-02, -1.004e-02, -1.042e-03],
+            [ 7.043e-03,  6.069e-03, -1.753e-03, -2.392e-03],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH3O3 PES calculated at
+    the ccsd(t)_l/aug-cc-pvtz-f12//b2plyp-d3/def2-tzvp level of theory. 
+    """,
+)
+
+entry(
+    index = 42,
+    label = "H + O=C(O)O <=> OH + HOCHO",
+    kinetics = Chebyshev(
+        coeffs = [
+            [-1.178e+01, -1.514e-02, -1.045e-02, -5.725e-03],
+            [ 2.033e+01,  6.300e-03,  4.337e-03,  2.365e-03],
+            [ 3.555e-02,  7.030e-03,  4.826e-03,  2.618e-03],
+            [ 2.403e-02, -8.282e-04, -5.560e-04, -2.900e-04],
+            [ 1.725e-02, -1.708e-03, -1.163e-03, -6.216e-04],
+            [ 1.103e-02,  7.036e-04,  4.775e-04,  2.539e-04],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (3000, 'K'),
+        Pmin = (0.01, 'bar'),
+        Pmax = (100, 'bar'),
+    ),
+    shortDesc = u"""ccsd(t)_l/aug-cc-pvtz//B2PLYP-D3/def2-TZVP""",
+    longDesc = 
+    u"""
+    From the pressure-dependent kinetic network of the singlet CH3O3 PES calculated at
+    the ccsd(t)_l/aug-cc-pvtz-f12//b2plyp-d3/def2-tzvp level of theory. 
+    """,
+)
+
+
+entry(
+    index = 43,
+    label = "HOCHO + HOCHO <=> HOCHO + CO + H2O",
+    kinetics = Arrhenius(A=(4.79e-01, '(cm^3/(mol*s))'), n=3.40, Ea=(104.59, 'kJ/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc = """ccsd(t)-f12/aug-cc-pvtz//wb97xd/def2tzvp""",
+    longDesc = 
+    """
+
+    TS method summary for TS0 in HOCHO + HOCHO <=> HOCHO + CO + H2O:
+
+    The method that generated the best TS guess and its output used for the optimization: user guess 0
+
+
+    TS external symmetry: 1, TS optical isomers: 2
+
+    Optimized TS geometry:
+    C      -5.31806600    0.95127700   -0.06259500
+    H      -6.50508100    1.09039000   -0.54026300
+    O      -4.34825500    1.36904000    0.38136900
+    O      -5.25710500   -0.77504500   -0.38224100
+    H      -4.39736300   -1.08534800   -0.67872700
+    C      -7.90086200   -0.00547300   -1.78732000
+    H      -8.84606200   -0.03244500   -2.34730600
+    O      -7.66242600    1.05094000   -1.14742800
+    O      -7.17500800   -1.02113300   -1.85083000
+    H      -6.08134000   -0.96262100   -1.09028200
+
+
+    No rotors considered for this TS.
+    """,
+)
+
+entry(
+    index=44,
+    label="HOCHO + HO2 <=> OCHO + H2O2",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(3.7E+01, 'cm^3/(mol*s)'), n=2.98, Ea=(25348, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=45,
+    label="HOCO + O2 <=> HOC(O)OO",
+    degeneracy=1,
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'atm'),
+        arrhenius=[
+            Arrhenius(A=(4.49E-09, 'cm^3/(mol*s)'), n=0.00, Ea=(-17910.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(3.68E-06, 'cm^3/(mol*s)'), n=0.00, Ea=(-10760.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(2.51E-11, 'cm^3/(mol*s)'), n=0.00, Ea=(-24300.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(4.70E-12, 'cm^3/(mol*s)'), n=5.21, Ea=(4355.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(8.71E+00, 'cm^3/(mol*s)'), n=2.17, Ea=(-2871.0, 'cal/mol'), T0=(1, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=46,
+    label="HOC(O)OO <=> CO2 + HO2",
+    degeneracy=1,
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'atm'),
+        arrhenius=[
+            Arrhenius(A=(8.16E+07, 's^-1'), n=0.00, Ea=(2680.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(3.42E+08, 's^-1'), n=0.11, Ea=(3091.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(6.35E+10, 's^-1'), n=-0.31, Ea=(4084.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(1.04E+12, 's^-1'), n=-0.40, Ea=(4916.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(3.22E+12, 's^-1'), n=-0.33, Ea=(5655.0, 'cal/mol'), T0=(1, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=47,
+    label="HOCO + O2 <=> CO2 + HO2",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(1.79E+16, 'cm^3/(mol*s)'), n=-1.23, Ea=(909.6, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=48,
+    label="HOCO + HO2 <=> HOCOO + OH",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(7.28E+12, 'cm^3/(mol*s)'), n=0.02, Ea=(118.6, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=49,
+    label="HOCO + HO2 <=> H2O + CO3",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(9.23E+08, 'cm^3/(mol*s)'), n=0.68, Ea=(-549.0, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=50,
+    label="HOCO + HO2 <=> H2O2 + CO2",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(3.31E+11, 'cm^3/(mol*s)'), n=0.16, Ea=(-196.5, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=51,
+    label="HOCO + HO2 <=> HOC(O)OOH",
+    degeneracy=1,
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'atm'),
+        arrhenius=[
+            Arrhenius(A=(2.63E+96, 'cm^3/(mol*s)'), n=-27.42, Ea=(55100.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(3.81E+15, 'cm^3/(mol*s)'), n=-3.25, Ea=(15410.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(3.31E+18, 'cm^3/(mol*s)'), n=-3.72, Ea=(6721.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(1.59E+28, 'cm^3/(mol*s)'), n=-5.94, Ea=(4270.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(1.11E+32, 'cm^3/(mol*s)'), n=-6.34, Ea=(5754.0, 'cal/mol'), T0=(1, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),
+
+entry(
+    index=52,
+    label="HOC(O)OOH <=> HOCOO + OH",
+    degeneracy=1,
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'atm'),
+        arrhenius=[
+            Arrhenius(A=(1.23E+46, 's^-1'), n=-10.57, Ea=(60710.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(2.29E+48, 's^-1'), n=-10.80, Ea=(62760.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(1.84E+46, 's^-1'), n=-9.84, Ea=(63380.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(1.69E+40, 's^-1'), n=-7.79, Ea=(62080.0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(1.29E+32, 's^-1'), n=-5.22, Ea=(59410.0, 'cal/mol'), T0=(1, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Yin2021]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12/CBS//M06-2X/6311++G(d,p)
+    """,
+),

--- a/input/thermo/libraries/FormicAcid.py
+++ b/input/thermo/libraries/FormicAcid.py
@@ -1,0 +1,994 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "formic_acid"
+shortDesc = u""
+longDesc = u"""
+Thermodynamic properties are calculated at the CCSD(T)-F12/cc-pVTZ-F12//B2PLYP-D3/aug-cc-pVTZ LOT.
+"""
+entry(
+    index = 0,
+    label = "DHC",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p1 c+1 {3,D} {4,S}
+3 C u0 p1 c-1 {1,S} {2,D}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.07335,-0.00551665,5.35174e-05,-7.42433e-08,3.36234e-11,-26056.1,6.51176], Tmin=(10,'K'), Tmax=(669.93,'K')),
+            NASAPolynomial(coeffs=[1.39698,0.0166722,-1.00661e-05,2.86469e-09,-3.13776e-13,-25836.8,17.3117], Tmin=(669.93,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-216.634,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (103.931,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'H-O': 2, 'C-O': 2}
+1D rotors:
+pivots: [2, 3], dihedral: [1, 2, 3, 5], rotor symmetry: 1, max scan energy: 76.57 kJ/mol
+* Invalidated! pivots: [1, 2], dihedral: [4, 1, 2, 3], invalidation reason: Another conformer for DHC exists which is 3.74 kJ/mol lower.Another conformer for DHC exists which is 3.74 kJ/mol lower.
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O      -0.78982700   -0.69533800    0.24542900
+C      -0.29640200    0.46228900    0.60519900
+O      -0.87328500    1.39980900   -0.15486200
+H      -1.44656600   -0.59221300   -0.47698800
+H      -0.50625500    2.25078100    0.11425000
+""",
+)
+
+entry(
+    index = 1,
+    label = "O=C1OOO1",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,S} {5,S}
+3 O u0 p2 c0 {1,S} {2,S}
+4 O u0 p2 c0 {5,D}
+5 C u0 p0 c0 {1,S} {2,S} {4,D}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.9588,0.00225325,4.9986e-05,-8.93951e-08,4.71859e-11,-19013.3,7.89072], Tmin=(10,'K'), Tmax=(629.161,'K')),
+            NASAPolynomial(coeffs=[2.92159,0.0191089,-1.46647e-05,5.03245e-09,-6.36001e-13,-19085.9,10.8], Tmin=(629.161,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-158.105,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (108.088,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C-O': 2, 'C=O': 1, 'O-O': 2}
+
+External symmetry: 2, optical isomers: 1
+
+Geometry:
+O       1.69896900   -0.10715400   -0.38756400
+C       0.52638500   -0.03319900   -0.41099400
+O      -0.35389500    0.78723700    0.23965400
+O      -1.44808700    0.09133100   -0.45044800
+O      -0.42337200   -0.73821500   -1.09821000
+""",
+)
+
+entry(
+    index = 2,
+    label = "[O]C[=O]O",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {4,S} {5,S}
+2 O u1 p2 c0 {4,S}
+3 O u0 p2 c0 {4,D}
+4 C u0 p0 c0 {1,S} {2,S} {3,D}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.96887,0.00169203,3.94826e-05,-6.91081e-08,3.59659e-11,-38527.7,8.4465], Tmin=(10,'K'), Tmax=(634.15,'K')),
+            NASAPolynomial(coeffs=[3.02302,0.0154686,-1.15787e-05,3.99334e-09,-5.09425e-13,-38564.8,11.3406], Tmin=(634.15,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-320.352,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (103.931,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C=O': 1, 'C-O': 2, 'H-O': 1}
+1D rotors:
+pivots: [2, 4], dihedral: [1, 2, 4, 5], rotor symmetry: 2, max scan energy: 33.72 kJ/mol
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O      -0.49052300    0.83432000   -0.92320200
+C      -0.32015100   -0.14009300   -0.13752900
+O      -1.19378700   -1.01499700   -0.17822400
+O       0.72010700   -0.22944700    0.67921700
+H       1.28435300    0.55021700    0.55973900
+""",
+)
+
+entry(
+    index = 3,
+    label = "[O]OC[=O]O",
+    molecule = 
+"""
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,D}
+2 O u0 p2 c0 {1,S} {5,S}
+3 O u0 p2 c0 {1,S} {6,S}
+4 O u0 p2 c0 {1,D}
+5 O u1 p2 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88492,0.00720949,8.56618e-05,-2.06726e-07,1.40058e-10,-36327.1,10.0503], Tmin=(10,'K'), Tmax=(527.147,'K')),
+            NASAPolynomial(coeffs=[5.45622,0.0188774,-1.46672e-05,5.05104e-09,-6.39e-13,-36820.6,0.36677], Tmin=(527.147,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-302.076,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (124.717,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C=O': 1, 'O-O': 1, 'C-O': 2, 'H-O': 1}
+1D rotors:
+pivots: [2, 3], dihedral: [1, 2, 3, 4], rotor symmetry: 1, max scan energy: 25.16 kJ/mol
+pivots: [3, 5], dihedral: [2, 3, 5, 6], rotor symmetry: 1, max scan energy: 40.62 kJ/mol
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       1.97154800   -0.51314500   -0.06349200
+O       0.67270200   -0.69642200    0.09340900
+C      -0.06751500    0.43319400   -0.33328700
+O       0.38354600    1.43317000   -0.77936900
+O      -1.33426100    0.09614400   -0.11405700
+H      -1.88307700    0.84402600   -0.39292900
+""",
+)
+
+entry(
+    index = 4,
+    label = "O[C]1OOO1",
+    molecule = 
+"""
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {5,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 O u0 p2 c0 {1,S} {4,S}
+4 O u0 p2 c0 {2,S} {3,S}
+5 O u0 p2 c0 {1,S} {6,S}
+6 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.90463,0.00589849,7.81231e-05,-1.80117e-07,1.18554e-10,9650.5,9.9171], Tmin=(10,'K'), Tmax=(534.789,'K')),
+            NASAPolynomial(coeffs=[4.86565,0.0187317,-1.40288e-05,4.76438e-09,-5.9818e-13,9261.41,3.2054], Tmin=(534.789,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (80.2075,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (128.874,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'O-O': 2, 'C-O': 3, 'H-O': 1}
+1D rotors:
+pivots: [1, 2], dihedral: [6, 1, 2, 3], rotor symmetry: 1, max scan energy: 17.33 kJ/mol
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       1.25547800   -0.10084000    0.43121100
+C       0.11531600   -0.08069300   -0.27714900
+O      -0.61842800    1.10069200   -0.25205800
+O      -1.80956900    0.29758000    0.05355500
+O      -0.92934600   -0.86996000    0.19234100
+H       1.98655100   -0.34677900   -0.14790000
+""",
+)
+
+entry(
+    index = 5,
+    label = "[C]1OO1",
+    molecule = 
+"""
+multiplicity 3
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 C u2 p0 c0 {1,S} {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.02353,-0.00205332,2.01618e-05,-3.30115e-08,1.81491e-11,26414.8,6.69132], Tmin=(10,'K'), Tmax=(543.095,'K')),
+            NASAPolynomial(coeffs=[3.37855,0.00442935,-2.52748e-06,7.13421e-10,-7.88855e-14,26459.3,9.17402], Tmin=(543.095,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (219.626,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (58.2013,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C-O': 2, 'O-O': 1}
+
+External symmetry: 2, optical isomers: 1
+
+Geometry:
+C      -0.14871100    0.61738500   -0.01032400
+O      -0.83209300   -0.52801300   -0.05350100
+O       0.98080500   -0.08937200    0.06382500
+""",
+)
+
+entry(
+    index = 6,
+    label = "[O][C]1OO1",
+    molecule = 
+"""
+multiplicity 3
+1 O u0 p2 c0 {2,S} {4,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 O u1 p2 c0 {4,S}
+4 C u1 p0 c0 {1,S} {2,S} {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.16232,0.0926311,-0.000549637,1.29378e-06,-1.05934e-09,-11777,15.6206], Tmin=(10,'K'), Tmax=(388.93,'K')),
+            NASAPolynomial(coeffs=[6.54607,0.00420699,-1.79705e-06,2.3099e-10,7.54724e-15,-11634.7,7.70545], Tmin=(388.93,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-97.9559,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (83.1447,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C-O': 3, 'O-O': 1}
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       1.36797300   -0.75525400    0.27943300
+C       2.09070800    0.09366700    0.09443800
+O      -1.48598500    0.87122900   -0.31715400
+O      -1.97269600   -0.20964100   -0.05671800
+""",
+)
+
+entry(
+    index = 7,
+    label = "[O]C1[O]OO1",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {5,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 O u0 p2 c0 {5,S} {6,S}
+4 O u1 p2 c0 {5,S}
+5 C u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
+6 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.92232,0.00476147,7.29026e-05,-1.60404e-07,1.02914e-10,-35594.7,10.2387], Tmin=(10,'K'), Tmax=(537.749,'K')),
+            NASAPolynomial(coeffs=[4.23929,0.0190827,-1.35694e-05,4.4765e-09,-5.53349e-13,-35870,6.66386], Tmin=(537.749,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-295.978,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (133.032,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C-O': 4, 'H-O': 1, 'O-O': 1}
+1D rotors:
+* Invalidated! pivots: [2, 3], dihedral: [1, 2, 3, 6], invalidation reason: Another conformer for [O]C1[O]OO1[323] exists which is 2.67 kJ/mol lower.Another conformer for [O]C1[O]OO1[323] exists which is 2.67 kJ/mol lower.
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       0.13168800    1.56944100   -0.39826200
+C      -0.01896600    0.42541800   -0.10941300
+O       0.89006200   -0.49985100    0.15169600
+O      -1.33292400   -0.07273100   -0.01693000
+O      -1.42331600   -1.35383600    0.30862600
+H       1.75345400   -0.06844100    0.06428200
+""",
+)
+
+entry(
+    index = 8,
+    label = "[O]C1OO1",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {4,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 O u1 p2 c0 {4,S}
+4 C u0 p0 c0 {1,S} {2,S} {3,S} {5,S}
+5 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.93632,0.00523728,2.95862e-05,-5.9734e-08,3.43164e-11,-10291.8,8.67808], Tmin=(10,'K'), Tmax=(582.122,'K')),
+            NASAPolynomial(coeffs=[3.53284,0.0141503,-9.20351e-06,2.81019e-09,-3.26242e-13,-10348.9,9.51273], Tmin=(582.122,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-85.5835,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (108.088,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C-O': 3, 'O-O': 1, 'C-H': 1}
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       1.46439500   -0.59205100    0.49694800
+C       0.52222200   -0.00147300    0.10219500
+O      -0.75496200   -0.63074200    0.07987000
+O      -1.66656300    0.20632300   -0.39733900
+H       0.43413300    1.02117600   -0.28168700
+""",
+)
+
+entry(
+    index = 9,
+    label = "O[CH]O",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,S} {6,S}
+3 C u1 p0 c0 {1,S} {2,S} {4,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.93294,0.00398729,5.80929e-05,-1.24559e-07,7.73948e-11,-23332.1,8.04999], Tmin=(10,'K'), Tmax=(565.246,'K')),
+            NASAPolynomial(coeffs=[4.70854,0.0139186,-9.18191e-06,3.04904e-09,-3.89996e-13,-23666.1,2.5716], Tmin=(565.246,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-194.02,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (128.874,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'H-O': 2, 'C-O': 2, 'C-H': 1}
+1D rotors:
+* Invalidated! pivots: [1, 2], dihedral: [4, 1, 2, 3], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+pivots: [2, 3], dihedral: [1, 2, 3, 6], rotor symmetry: 1, max scan energy: 16.17 kJ/mol
+
+
+External symmetry: 1, optical isomers: 2
+
+Geometry:
+O      -1.26385900    0.10555800    0.39811000
+C      -0.00644600    0.35447800   -0.11540000
+O       0.53122600    1.49114500    0.39520100
+H      -1.67487300   -0.58879300   -0.12800600
+H       0.70490700   -0.46880000   -0.10152200
+H      -0.17687700    2.14325200    0.47561800
+""",
+)
+
+entry(
+    index = 10,
+    label = "CH2O3[20]",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,D}
+2 O u0 p2 c0 {1,S} {5,S}
+3 O u0 p2 c0 {1,S} {6,S}
+4 O u0 p2 c0 {1,D}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94605,0.00299625,6.16257e-05,-1.13518e-07,6.16657e-11,-75640.7,6.85646], Tmin=(10,'K'), Tmax=(617.147,'K')),
+            NASAPolynomial(coeffs=[3.10828,0.0217263,-1.62249e-05,5.50008e-09,-6.9305e-13,-75790.5,8.44184], Tmin=(617.147,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-628.937,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (124.717,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C=O': 1, 'H-O': 2, 'C-O': 2}
+1D rotors:
+pivots: [2, 3], dihedral: [1, 2, 3, 5], rotor symmetry: 1, max scan energy: 44.00 kJ/mol
+pivots: [2, 4], dihedral: [1, 2, 4, 6], rotor symmetry: 1, max scan energy: 44.00 kJ/mol
+
+
+External symmetry: 2, optical isomers: 1
+
+Geometry:
+O       0.62733600    1.44401200    0.23764000
+C       0.03063800    0.40692200    0.10049800
+O      -1.27020700    0.21576800    0.34845400
+O       0.55768300   -0.74682700   -0.32530500
+H      -1.61600800    1.06611200    0.65249700
+H       1.49362800   -0.57146800   -0.49371100
+""",
+)
+
+entry(
+    index = 11,
+    label = "C2H4O3[183]",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {5,S}
+2 O u0 p2 c0 {4,S} {9,S}
+3 O u0 p2 c0 {5,D}
+4 C u0 p0 c0 {1,S} {2,S} {6,S} {7,S}
+5 C u0 p0 c0 {1,S} {3,D} {8,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {5,S}
+9 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.92374,0.0044405,9.92695e-05,-1.8914e-07,1.08907e-10,-67674.2,10.2514], Tmin=(10,'K'), Tmax=(569.557,'K')),
+            NASAPolynomial(coeffs=[2.28908,0.0333374,-2.27034e-05,7.31907e-09,-8.93064e-13,-67770.5,14.7376], Tmin=(569.557,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-562.707,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C=O': 1, 'H-O': 1, 'C-H': 3, 'C-O': 3}
+1D rotors:
+* Invalidated! pivots: [2, 3], dihedral: [1, 2, 3, 4], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+* Invalidated! pivots: [3, 4], dihedral: [2, 3, 4, 5], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+pivots: [4, 5], dihedral: [3, 4, 5, 9], rotor symmetry: 1, max scan energy: 25.04 kJ/mol
+
+
+External symmetry: 1, optical isomers: 2
+
+Geometry:
+O       1.84273600    0.80564200    0.59027800
+C       1.58279400   -0.19083500   -0.03942700
+O       0.35680200   -0.59234100   -0.38294400
+C      -0.70769300    0.30827600    0.03350700
+O      -0.84723000    0.36286600    1.40437300
+H       2.32859700   -0.90161300   -0.40996300
+H      -0.49407200    1.28248400   -0.40747200
+H      -1.60610300   -0.13109000   -0.38428600
+H      -0.10633500    0.87990500    1.74773400
+""",
+)
+
+entry(
+    index = 12,
+    label = "CH2O4[194]",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {5,D}
+2 O u0 p2 c0 {1,S} {4,S}
+3 O u0 p2 c0 {1,S} {6,S}
+4 O u0 p2 c0 {2,S} {7,S}
+5 O u0 p2 c0 {1,D}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85404,0.00959427,0.00010179,-2.6977e-07,1.99028e-10,-63896.8,9.16176], Tmin=(10,'K'), Tmax=(490.885,'K')),
+            NASAPolynomial(coeffs=[6.17327,0.0190312,-1.36304e-05,4.57166e-09,-5.76383e-13,-64465.9,-3.85431], Tmin=(490.885,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-531.3,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (149.66,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C=O': 1, 'O-O': 1, 'H-O': 2, 'C-O': 2}
+1D rotors:
+pivots: [2, 3], dihedral: [1, 2, 3, 6], rotor symmetry: 1, max scan energy: 36.90 kJ/mol
+* Invalidated! pivots: [2, 4], dihedral: [1, 2, 4, 5], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+pivots: [4, 5], dihedral: [2, 4, 5, 7], rotor symmetry: 1, max scan energy: 13.84 kJ/mol
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       0.22532000    1.14212400    0.42977700
+C       0.37536100    0.04990500   -0.06283500
+O       1.46072100   -0.71698300   -0.00378500
+O      -0.55376500   -0.60152400   -0.77752500
+O      -1.74840600    0.19689500   -0.86571800
+H       2.11929900   -0.23249300    0.51434800
+H      -1.47982300    0.99058700   -0.35171900
+""",
+)
+
+entry(
+    index = 13,
+    label = "[O]C[[O]]O[222]",
+    molecule = 
+"""
+multiplicity 3
+1 O u0 p2 c0 {4,S} {6,S}
+2 O u1 p2 c0 {4,S}
+3 O u1 p2 c0 {4,S}
+4 C u0 p0 c0 {1,S} {2,S} {3,S} {5,S}
+5 H u0 p0 c0 {4,S}
+6 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94547,0.00319543,6.16641e-05,-1.21967e-07,7.1897e-11,-10258.9,9.8819], Tmin=(10,'K'), Tmax=(569.247,'K')),
+            NASAPolynomial(coeffs=[3.47466,0.0190356,-1.3098e-05,4.26377e-09,-5.25052e-13,-10408.4,10.1046], Tmin=(569.247,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-85.3198,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (133.032,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'H-O': 1, 'C-H': 1, 'C-O': 3}
+1D rotors:
+* Invalidated! pivots: [2, 4], dihedral: [1, 2, 4, 6], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+
+
+External symmetry: 1, optical isomers: 2
+
+Geometry:
+O      -0.83633100    1.32959800    0.30960400
+C      -0.34906800    0.05785900    0.24481300
+O      -0.44550300   -0.31103400   -1.07739600
+O       0.92882600   -0.14457400    0.73046000
+H      -1.03690100   -0.49735300    0.91296400
+H       1.54993300    0.25726300    0.10679800
+""",
+)
+
+entry(
+    index = 14,
+    label = "OC1OO1[239]",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u0 p2 c0 {1,S} {2,S}
+4 O u0 p2 c0 {1,S} {6,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.0955,-0.00811778,0.000106168,-1.74792e-07,8.97178e-11,-28933.5,8.10056], Tmin=(10,'K'), Tmax=(650.132,'K')),
+            NASAPolynomial(coeffs=[3.05265,0.0215236,-1.58069e-05,5.23388e-09,-6.38612e-13,-29288.7,8.90783], Tmin=(650.132,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-240.572,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (128.874,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'O-O': 1, 'H-O': 1, 'C-H': 1, 'C-O': 3}
+1D rotors:
+pivots: [1, 2], dihedral: [5, 1, 2, 3], rotor symmetry: 1, max scan energy: 26.02 kJ/mol
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       1.08900000    0.44632000   -0.00610100
+C      -0.24765200    0.26502000    0.00223000
+O      -0.78833000   -0.75358100    0.76819600
+O      -0.79834000   -0.75006600   -0.76126700
+H       1.50999700   -0.42577800   -0.01086200
+H      -0.76467500    1.21808600    0.00780500
+""",
+)
+
+entry(
+    index = 15,
+    label = "[O]O[C]1OO1[268]",
+    molecule = 
+"""
+multiplicity 3
+1 O u0 p2 c0 {2,S} {5,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 O u0 p2 c0 {4,S} {5,S}
+4 O u1 p2 c0 {3,S}
+5 C u1 p0 c0 {1,S} {2,S} {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86872,0.014298,7.12427e-06,-2.99464e-08,1.7165e-11,65677.5,10.8387], Tmin=(10,'K'), Tmax=(728.917,'K')),
+            NASAPolynomial(coeffs=[6.04348,0.0121154,-8.45172e-06,2.653e-09,-3.10647e-13,65101.3,-0.742717], Tmin=(728.917,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (546.066,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (108.088,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'O-O': 2, 'C-O': 3}
+1D rotors:
+* Invalidated! pivots: [2, 3], dihedral: [1, 2, 3, 4], invalidation reason: Another conformer for [O]O[C]1OO1[268] exists which is 1.60 kJ/mol lower.Another conformer for [O]O[C]1OO1[268] exists which is 1.60 kJ/mol lower.
+
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+O       2.00068600    0.09623500   -0.03518900
+O       0.83328800   -0.15390900    0.54986400
+C      -0.23828500    0.10068600   -0.31905500
+O      -1.26708100   -0.75989700   -0.35214800
+O      -1.32875700    0.72020600    0.15758300
+""",
+)
+
+entry(
+    index = 16,
+    label = "OC1[O]OO1[283]",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u0 p2 c0 {1,S} {2,S}
+4 O u0 p2 c0 {1,S} {6,S}
+5 O u0 p2 c0 {1,S} {7,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84606,0.00998608,0.000101388,-2.68274e-07,1.95365e-10,-54677.9,8.26505], Tmin=(10,'K'), Tmax=(502.184,'K')),
+            NASAPolynomial(coeffs=[6.68619,0.0178346,-1.30697e-05,4.49808e-09,-5.77985e-13,-55347.3,-7.30618], Tmin=(502.184,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-454.655,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (149.66,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'O-O': 1, 'H-O': 2, 'C-O': 4}
+1D rotors:
+pivots: [1, 2], dihedral: [6, 1, 2, 3], rotor symmetry: 1, max scan energy: 16.88 kJ/mol
+pivots: [2, 3], dihedral: [1, 2, 3, 7], rotor symmetry: 1, max scan energy: 16.87 kJ/mol
+
+
+External symmetry: 2, optical isomers: 1
+
+Geometry:
+O       1.36902900   -0.00830400   -0.20727200
+C       0.04188400    0.12816000   -0.03901400
+O      -0.29380500    1.40144000   -0.31163000
+O      -0.80012800   -0.89573400   -0.45391600
+O      -0.57405800   -0.51965800    1.02420500
+H       1.59526700   -0.92582400   -0.00843100
+H      -1.24779400    1.48451300   -0.18685900
+""",
+)
+
+entry(
+    index = 17,
+    label = "O1OC12OO2[297]",
+    molecule = 
+"""
+1 O u0 p2 c0 {2,S} {5,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 O u0 p2 c0 {4,S} {5,S}
+4 O u0 p2 c0 {3,S} {5,S}
+5 C u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94698,0.00292556,5.4325e-05,-1.01803e-07,5.5408e-11,-1582.16,7.12897], Tmin=(10,'K'), Tmax=(626.885,'K')),
+            NASAPolynomial(coeffs=[3.60176,0.018385,-1.43864e-05,5.00229e-09,-6.38218e-13,-1799.36,6.55567], Tmin=(626.885,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-13.1793,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (108.088,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'O-O': 2, 'C-O': 4}
+
+External symmetry: 4, optical isomers: 1
+
+Geometry:
+O       1.09233900   -0.57132100    0.52937300
+O       1.08036900    0.58654100   -0.53723300
+C       0.00000000    0.00000000    0.00000000
+O      -1.08471200   -0.54091800   -0.57502500
+O      -1.08799500    0.52569800    0.58288500
+""",
+)
+
+entry(
+    index = 18,
+    label = "O[C][O]O[18]",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {4,S} {5,S}
+2 O u0 p2 c0 {4,S} {6,S}
+3 O u0 p2 c0 {4,S} {7,S}
+4 C u1 p0 c0 {1,S} {2,S} {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84601,0.0109214,9.43581e-05,-2.86388e-07,2.37473e-10,-47720.4,8.74115], Tmin=(10,'K'), Tmax=(442.516,'K')),
+            NASAPolynomial(coeffs=[6.07727,0.0164138,-1.12432e-05,3.74861e-09,-4.72884e-13,-48169.1,-3.04319], Tmin=(442.516,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-396.782,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (149.66,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'H-O': 3, 'C-O': 3}
+1D rotors:
+pivots: [1, 2], dihedral: [5, 1, 2, 3], rotor symmetry: 1, max scan energy: 14.26 kJ/mol
+* Invalidated! pivots: [2, 3], dihedral: [1, 2, 3, 6], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+pivots: [2, 4], dihedral: [1, 2, 4, 7], rotor symmetry: 1, max scan energy: 14.26 kJ/mol
+
+
+External symmetry: 3, optical isomers: 2
+
+Geometry:
+O       0.24202700    1.23907400   -0.39432000
+C       0.08011600    0.01448500    0.19516600
+O       0.78631900   -0.96162300   -0.45431100
+O      -1.24121900   -0.31599200    0.33003100
+H      -0.28367200    1.87629400    0.10366800
+H       1.70172600   -0.66537200   -0.52262000
+H      -1.28529800   -1.18686500    0.74238500
+""",
+)
+
+entry(
+    index = 19,
+    label = "[CH]1OO1[168]",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 C u1 p0 c0 {1,S} {2,S} {4,S}
+4 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.07697,-0.00572596,4.68985e-05,-6.67202e-08,3.06201e-11,27222.5,7.05763], Tmin=(10,'K'), Tmax=(696.583,'K')),
+            NASAPolynomial(coeffs=[2.58418,0.0111392,-7.27659e-06,2.21944e-09,-2.55876e-13,27229.3,12.2755], Tmin=(696.583,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (226.35,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (83.1447,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'C-O': 2, 'C-H': 1, 'O-O': 1}
+
+External symmetry: 1, optical isomers: 1
+
+Geometry:
+C       0.26094900   -0.00466700    0.34185400
+O      -0.74949600   -0.77643400   -0.12724200
+O      -0.75615100    0.77383400   -0.10099800
+H       1.25294500    0.00736100   -0.11713600
+""",
+)
+
+entry(
+    index = 20,
+    label = "CH2O4[297]",
+    molecule = 
+"""
+multiplicity 3
+1 O u0 p2 c0 {5,S} {6,S}
+2 O u0 p2 c0 {5,S} {7,S}
+3 O u1 p2 c0 {5,S}
+4 O u1 p2 c0 {5,S}
+5 C u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86599,0.00866231,0.000100342,-2.5293e-07,1.80068e-10,-35062.7,11.0388], Tmin=(10,'K'), Tmax=(502.257,'K')),
+            NASAPolynomial(coeffs=[5.69077,0.0206559,-1.46986e-05,4.9207e-09,-6.18227e-13,-35580.5,0.161199], Tmin=(502.257,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-291.561,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (157.975,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+Bond corrections: {'H-O': 2, 'C-O': 4}
+1D rotors:
+* Invalidated! pivots: [2, 4], dihedral: [1, 2, 4, 6], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+* Invalidated! pivots: [2, 5], dihedral: [1, 2, 5, 7], invalidation reason: Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.Significant difference observed between consecutive conformers But unable to propose troubleshooting methods.
+
+
+External symmetry: 1, optical isomers: 2
+
+Geometry:
+O      -0.74299200    1.27405400   -0.36399300
+C       0.10017900    0.24657500    0.07105800
+O       0.59910600    0.80407900    1.18576800
+O      -0.69840700   -0.87000700    0.27412600
+O       1.06543300   -0.02158500   -0.85651400
+H      -1.09964500   -0.78943500    1.14957500
+H       0.71053500   -0.66552700   -1.48436800
+""",
+)
+
+entry(
+    index = 21,
+    label = "O[C]1OO1[262]",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {4,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 O u0 p2 c0 {4,S} {5,S}
+4 C u1 p0 c0 {1,S} {2,S} {3,S}
+5 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.93537,0.00417763,5.42901e-05,-1.31746e-07,9.21733e-11,-945.911,9.66795], Tmin=(10,'K'), Tmax=(500.046,'K')),
+            NASAPolynomial(coeffs=[4.45112,0.0126538,-8.9382e-06,2.94887e-09,-3.6476e-13,-1155.04,5.96183], Tmin=(500.046,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-7.8807,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (103.931,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+lot: qbs
+Bond corrections: {'O-O': 1, 'C-O': 3, 'H-O': 1}
+1D rotors:
+pivots: [1, 2], dihedral: [5, 1, 2, 3], rotor symmetry: 1, max scan energy: 8.51 kJ/mol
+
+
+External symmetry: 1, optical isomers: 2
+
+Geometry:
+O       1.12098400    0.08488700    0.46174100
+C      -0.21583100   -0.07414000    0.49745000
+O      -0.82952400   -0.17769200    1.68732900
+O      -1.09909000    0.95805500    0.67101500
+H       1.42219500   -0.00452400   -0.44992500
+""",
+)
+
+entry(
+    index = 22,
+    label = "OO[C]1OO1[266]",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {5,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 O u0 p2 c0 {4,S} {5,S}
+4 O u0 p2 c0 {3,S} {6,S}
+5 C u1 p0 c0 {1,S} {2,S} {3,S}
+6 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.80238,0.0193202,-2.90836e-06,-1.79305e-08,1.16996e-11,11141,11.4911], Tmin=(10,'K'), Tmax=(742.511,'K')),
+            NASAPolynomial(coeffs=[6.24867,0.0143622,-9.49925e-06,2.89769e-09,-3.33483e-13,10551.2,-1.10856], Tmin=(742.511,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (92.616,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (128.874,'J/(mol*K)'),
+    ),
+    shortDesc = """""",
+    longDesc = 
+"""
+lot: qbs
+Bond corrections: {'O-O': 2, 'C-O': 3, 'H-O': 1}
+1D rotors:
+pivots: [1, 2], dihedral: [6, 1, 2, 3], rotor symmetry: 1, max scan energy: 20.57 kJ/mol
+* Invalidated! pivots: [2, 3], dihedral: [1, 2, 3, 4], invalidation reason: Bond ([[1, 2]]) broke during the scan. But unable to propose troubleshooting methods.Bond ([[1, 2]]) broke during the scan. But unable to propose troubleshooting methods.
+
+
+External symmetry: 1, optical isomers: 2
+
+Geometry:
+O       1.72065500   -0.34247800   -0.33672600
+O       0.48268500   -0.64589200    0.37697300
+C       0.72880800   -1.73239800    1.14470900
+O       1.04906900   -1.66451300    2.47364900
+O      -0.29067500   -2.18015900    1.88999400
+H       1.84463500    0.57342900   -0.04503800
+""",
+)


### PR DESCRIPTION
This PR adds a new Formic Acid (HOCHO) kinetics library to improve the representation of HOCHO-related chemistry in combustion and oxidation mechanisms.

The library is primarily composed of reactions derived from our ab initio potential energy surface (PES) calculations:

- HOCHO PES
- HOCO PES

These reactions include pressure-dependent kinetics where applicable and are provided in RMG-compatible formats.

In addition to the computed PES reactions, the library also contains curated reactions collected from various literature sources and existing mechanisms to ensure reasonable coverage of surrounding reaction channels and radical chemistry.