### PR TITLE
Forbid trioxidanyl [O]OO which creates singlet O2

### DIFF
--- a/input/kinetics/families/Birad_R_Recombination/groups.py
+++ b/input/kinetics/families/Birad_R_Recombination/groups.py
@@ -1019,3 +1019,20 @@ instances with a different number of lone pairs are forbidden
 """,
 )
 
+forbidden(
+    label = "trioxidanyl",
+    group =
+"""
+multiplicity [2]
+1 *2 O u1 p2 c0 {2,S}
+2 *1 O u0 p2 c0 {1,S} {3,S}
+3    O u0 p2 c0 {2,S} {4,S}
+4    H u0 p0 c0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid this species because it decays and gives you [O] + [O]O <=> O2(singlet) + OH
+even if you have forbidden singlet O2 in your mechanism
+""",
+)

--- a/input/kinetics/families/R_Recombination/groups.py
+++ b/input/kinetics/families/R_Recombination/groups.py
@@ -2782,3 +2782,21 @@ u"""
 
 """,
 )
+
+forbidden(
+    label = "trioxidanyl",
+    group =
+"""
+multiplicity [2]
+1   O u1 p2 c0 {2,S}
+2 * O u0 p2 c0 {1,S} {3,S}
+3 * O u0 p2 c0 {2,S} {4,S}
+4   H u0 p0 c0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid this species because it decays and gives you O2 + OH <=> O2(singlet) + OH
+even if you have forbidden singlet O2 in your mechanism
+""",
+)


### PR DESCRIPTION
Forbid [O]OO species as a product of the R Recombination family because it decays and gives you O2 + OH <=> O2(singlet) + OH even if you have forbidden singlet O2 in your mechanism

Related to these issues:
https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2849 (fixes this one)

https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2848 (doesn't necessarily fix this one, but may prevent it from being an issue)

I have tested this with the following code:
```
import rmgpy.data.rmg

database = rmgpy.data.rmg.RMGDatabase()
database.load(
    path = rmgpy.settings['database.directory'],
    thermo_libraries = ['primaryThermoLibrary'],
    transport_libraries = [],
    reaction_libraries = [],
    seed_mechanisms = [],
    kinetics_families = ['R_Recombination'],
    kinetics_depositories = ['training'],
    depository = False,
) 

for family in database.kinetics.families:
    if not database.kinetics.families[family].auto_generated:
        database.kinetics.families[family].add_rules_from_training(thermo_database=database.thermo)
        database.kinetics.families[family].fill_rules_by_averaging_up(verbose=True)

my_reaction = rmgpy.reaction.Reaction()
my_reaction.reactants = [
    rmgpy.species.Species(smiles='[O][O]'),
    rmgpy.species.Species(smiles='[OH]')
]

possible = database.kinetics.families['R_Recombination']._generate_reactions([x.molecule[0] for x in my_reaction.reactants])
for p in possible:
    print(p)
# doesn't print anything because there are no possible reactions once you forbid the [O]OO group
```

I tested this on my propane mechanism and it no longer generates singlet O2. 