### PR TITLE
try to suppress conda.cli regression test error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,7 +225,9 @@ jobs:
               export FAILED=Yes
             fi
             echo "" # blank line so next block is interpreted as markdown
+            echo '```'
             cat "$regr_test-core.log" || (echo "Dumping the whole log failed, please download it from GitHub actions. Here are the first 100 lines:" && head -n100 "$regr_test-core.log")
+            echo '```'
             echo "</details>"
             echo "<details>"
             if conda run -n rmg_env_without_rms python scripts/checkModels.py \
@@ -242,7 +244,9 @@ jobs:
               export FAILED=Yes
             fi
             echo "" # blank line so next block is interpreted as markdown
+            echo '```'
             cat "$regr_test-edge.log" || (echo "Dumping the whole log failed, please download it from GitHub actions. Here are the first 100 lines:" && head -n100 "$regr_test-core.log")
+            echo '```'
             echo "</details>"
 
             # Check for Regression between Reference and Dynamic (skip superminimal)


### PR DESCRIPTION
There's still a weird error in the database regression tests. This tries to suppress it or see what the problem is.

```
ERROR conda.cli.main_run:execute(148): conda run python scripts/checkModels.py aromatics-edge stable_regression_results/aromatics/chemkin/chem_edge_annotated.inp stable_regression_results/aromatics/chemkin/species_edge_dictionary.txt test/regression/aromatics/chemkin/chem_edge_annotated.inp test/regression/aromatics/chemkin/species_edge_dictionary.txt failed. (See above for error)
ERROR conda.cli.main_run:execute(148): conda run python scripts/checkModels.py liquid_oxidation-edge stable_regression_results/liquid_oxidation/chemkin/chem_edge_annotated.inp stable_regression_results/liquid_oxidation/chemkin/species_edge_dictionary.txt test/regression/liquid_oxidation/chemkin/chem_edge_annotated.inp test/regression/liquid_oxidation/chemkin/species_edge_dictionary.txt failed. (See above for error)
ERROR conda.cli.main_run:execute(148): conda run python scripts/checkModels.py nitrogen-core stable_regression_results/nitrogen/chemkin/chem_annotated.inp stable_regression_results/nitrogen/chemkin/species_dictionary.txt test/regression/nitrogen/chemkin/chem_annotated.inp test/regression/nitrogen/chemkin/species_dictionary.txt failed. (See above for error)
ERROR conda.cli.main_run:execute(148): conda run python scripts/checkModels.py nitrogen-edge stable_regression_results/nitrogen/chemkin/chem_edge_annotated.inp stable_regression_results/nitrogen/chemkin/species_edge_dictionary.txt test/regression/nitrogen/chemkin/chem_edge_annotated.inp test/regression/nitrogen/chemkin/species_edge_dictionary.txt failed. (See above for error)
WARNING:root:Initial mole fractions do not sum to one; normalizing.
ERROR conda.cli.main_run:execute(148): conda run python scripts/checkModels.py sulfur-edge stable_regression_results/sulfur/chemkin/chem_edge_annotated.inp stable_regression_results/sulfur/chemkin/species_edge_dictionary.txt test/regression/sulfur/chemkin/chem_edge_annotated.inp test/regression/sulfur/chemkin/species_edge_dictionary.txt failed. (See above for error)
ERROR conda.cli.main_run:execute(148): conda run python scripts/checkModels.py RMS_CSTR_liquid_oxidation-core stable_regression_results/RMS_CSTR_liquid_oxidation/chemkin/chem_annotated.inp stable_regression_results/RMS_CSTR_liquid_oxidation/chemkin/species_dictionary.txt test/regression/RMS_CSTR_liquid_oxidation/chemkin/chem_annotated.inp test/regression/RMS_CSTR_liquid_oxidation/chemkin/species_dictionary.txt failed. (See above for error)
ERROR conda.cli.main_run:execute(148): conda run python scripts/checkModels.py RMS_CSTR_liquid_oxidation-edge stable_regression_results/RMS_CSTR_liquid_oxidation/chemkin/chem_edge_annotated.inp stable_regression_results/RMS_CSTR_liquid_oxidation/chemkin/species_edge_dictionary.txt test/regression/RMS_CSTR_liquid_oxidation/chemkin/chem_edge_annotated.inp test/regression/RMS_CSTR_liquid_oxidation/chemkin/species_edge_dictionary.txt failed. (See above for error)
⚠️ One or more regression tests failed.
```