### PR TITLE
RMG-database v4.0.0 :tada:

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,7 +1,7 @@
 # For conda build
 package:
   name: rmgdatabase
-  version: 4.0.0.rc1
+  version: 4.0.0
 
 source:
   path: ../


### PR DESCRIPTION
Official release of RMG-database v4.0.0 coinciding with the upcoming manuscript.

Pair PR on RMG-Py: https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2967